### PR TITLE
feat: usage 进度条加本月时间进度标记

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,7 +62,7 @@ src/app/                 # App Router：页面与布局
       @submit/page.tsx
       @usage/page.tsx
       @list/page.tsx
-  _components/           # 如 auth-check、navbar、set-budget-trigger（非 route segment）
+  _components/           # 如 auth-check、navbar、set-budget-trigger、progress-bar（非 route segment）
   _context/              # 如 auth-session
 src/api/                 # 与 Supabase 的查询/变更封装（如 usage、user-budget-settings、monthly-settlements）
 src/styles/              # 全局样式
@@ -123,6 +123,7 @@ flowchart LR
   - 某月结算预算 = 该月有效预算（`time_to_effect <= 该月` 中 `time_to_effect` 最大、`id` 最大的一条）。
   - 月份归属按浏览器本地时区分桶，与 `YYYYMM` month key 口径一致；月份键工具为 `addMonthsKey`。
   - UI 不单独展示结余；进度条分母为 `totalAvailable = 本月预算 + 累计结余`，`usagePercent` 基于 `totalAvailable` 计算。
+- **进度条时间进度标记**：`/record/@usage` 的进度条由 [`src/app/_components/progress-bar.tsx`](src/app/_components/progress-bar.tsx) 的 `ProgressBar` 渲染，可选参数 `markerPercent` 在对应百分比位置渲染一条竖线标记（不传则不渲染）。标记与进度条等高，两侧用 `mask-image` 渐变把轨道/填充抠出透明小缺口（不依赖表面色），线色统一为 `green-600`。注意本项目的深浅色主题靠 `prefers-color-scheme` 媒体查询驱动，没有 `.dark` 类，因此 class 式的 `dark:` 变体不生效。@usage 传入的是 `UsageSummary.monthElapsedPercent`（[`src/api/usage.ts`](src/api/usage.ts) 的 `getMonthElapsedPercent`）：今天（含）是当月第几天 / 当月总天数，浏览器本地时区，用于对比消费进度与时间进度。
 
 ## Git 与提交
 

--- a/src/api/usage.test.ts
+++ b/src/api/usage.test.ts
@@ -5,6 +5,7 @@ import {
   buildBudgetTimeline,
   buildSettlementRows,
   buildUsageItem,
+  getMonthElapsedPercent,
   planPendingSettlements,
   sumSettledDeltaByCurrency,
 } from "./usage";
@@ -30,6 +31,28 @@ describe("addMonthsKey", () => {
 
   it("crosses the year boundary backward", () => {
     expect(addMonthsKey(202601, -2)).toBe(202511);
+  });
+});
+
+describe("getMonthElapsedPercent", () => {
+  it("returns the day-of-month ratio for a mid-month date", () => {
+    expect(getMonthElapsedPercent(new Date(2026, 7, 6))).toBeCloseTo((6 / 31) * 100);
+  });
+
+  it("returns 100 on the last day of the month", () => {
+    expect(getMonthElapsedPercent(new Date(2026, 7, 31))).toBe(100);
+  });
+
+  it("returns 50 mid-February in a non-leap year", () => {
+    expect(getMonthElapsedPercent(new Date(2026, 1, 14))).toBe(50);
+  });
+
+  it("returns 100 on Feb 29 in a leap year", () => {
+    expect(getMonthElapsedPercent(new Date(2024, 1, 29))).toBe(100);
+  });
+
+  it("returns the first-day ratio on the 1st", () => {
+    expect(getMonthElapsedPercent(new Date(2026, 3, 1))).toBeCloseTo((1 / 30) * 100);
   });
 });
 

--- a/src/api/usage.ts
+++ b/src/api/usage.ts
@@ -40,6 +40,7 @@ export type UsageSummary = {
   hasBudget: boolean;
   isFirstSetup: boolean;
   items: UsageSummaryItem[];
+  monthElapsedPercent: number;
 };
 
 // 上个月始终按明细实时计算，只有上上月及更早才归档结算
@@ -55,6 +56,12 @@ function getMonthStartFromKey(monthKey: number): Date {
   const year = Math.floor(monthKey / 100);
   const monthIndex = (monthKey % 100) - 1;
   return new Date(year, monthIndex, 1, 0, 0, 0, 0);
+}
+
+// 本月时间进度：今天（含）是当月第几天 / 当月总天数，本地时区
+export function getMonthElapsedPercent(date: Date): number {
+  const daysInMonth = new Date(date.getFullYear(), date.getMonth() + 1, 0).getDate();
+  return (date.getDate() / daysInMonth) * 100;
 }
 
 function toMapByCurrency(records: AmountRecord[]): Record<string, number> {
@@ -194,6 +201,7 @@ export async function getUsageSummary(): Promise<UsageSummary> {
   const now = new Date();
   const currentMonthKey = getMonthKey(now);
   const prevMonthKey = addMonthsKey(currentMonthKey, -1);
+  const monthElapsedPercent = getMonthElapsedPercent(now);
 
   const [
     { data: budgetData, error: budgetError },
@@ -244,6 +252,7 @@ export async function getUsageSummary(): Promise<UsageSummary> {
       hasBudget: false,
       isFirstSetup,
       items: [],
+      monthElapsedPercent,
     };
   }
 
@@ -305,5 +314,6 @@ export async function getUsageSummary(): Promise<UsageSummary> {
     hasBudget: true,
     isFirstSetup,
     items,
+    monthElapsedPercent,
   };
 }

--- a/src/app/(index)/record/@usage/page.tsx
+++ b/src/app/(index)/record/@usage/page.tsx
@@ -6,6 +6,7 @@ import { use } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import { getUsageSummary } from "@/src/api/usage";
+import ProgressBar from "@/src/app/_components/progress-bar";
 import SetBudgetTrigger from "@/src/app/_components/set-budget-trigger";
 import { AuthSessionCtx } from "@/src/app/_context/auth-session-ctx";
 
@@ -115,7 +116,6 @@ export default function UsagePage() {
           <p className="text-sm font-semibold">Monthly Budget Usage (Daily)</p>
           {data.items.map((item) => {
             const percentText = `${item.usagePercent.toFixed(1)}%`;
-            const progressPercent = Math.min(item.usagePercent, 100);
 
             return (
               <div key={`budget-${item.currencyType}`} className="space-y-1">
@@ -123,12 +123,7 @@ export default function UsagePage() {
                   <span className="text-muted-foreground">{item.currencyType}</span>
                   <span className="font-semibold">{percentText}</span>
                 </div>
-                <div className="h-2 w-full rounded-full bg-muted overflow-hidden">
-                  <div
-                    className="h-full rounded-full bg-primary transition-[width]"
-                    style={{ width: `${progressPercent}%` }}
-                  />
-                </div>
+                <ProgressBar markerPercent={data.monthElapsedPercent} percent={item.usagePercent} />
                 <p className="text-xs text-muted-foreground text-right">
                   {currencySymbols[item.currencyType] || item.currencyType}
                   {item.monthTotal.toFixed(2)} / {currencySymbols[item.currencyType] || item.currencyType}

--- a/src/app/(index)/record/@usage/page.tsx
+++ b/src/app/(index)/record/@usage/page.tsx
@@ -123,7 +123,7 @@ export default function UsagePage() {
                   <span className="text-muted-foreground">{item.currencyType}</span>
                   <span className="font-semibold">{percentText}</span>
                 </div>
-                <ProgressBar markerPercent={data.monthElapsedPercent} percent={item.usagePercent} />
+                <ProgressBar ariaLabel={`${item.currencyType} monthly budget usage`} markerPercent={data.monthElapsedPercent} percent={item.usagePercent} />
                 <p className="text-xs text-muted-foreground text-right">
                   {currencySymbols[item.currencyType] || item.currencyType}
                   {item.monthTotal.toFixed(2)} / {currencySymbols[item.currencyType] || item.currencyType}

--- a/src/app/_components/progress-bar.tsx
+++ b/src/app/_components/progress-bar.tsx
@@ -1,0 +1,54 @@
+import { cn } from "@/lib/utils";
+
+type ProgressBarProps = {
+  className?: string;
+  /** 可选标记位置（0-100），不传则不渲染标记；超出范围会被 clamp */
+  markerPercent?: number;
+  /** 填充比例（0-100+），超出 100 按 100 渲染 */
+  percent: number;
+};
+
+function clampPercent(value: number): number {
+  return Math.min(Math.max(value, 0), 100);
+}
+
+// 标记两侧各 2px 用 mask 把轨道+填充抠出透明缺口，直接露出下方底色（无需关心表面色）
+function buildCutMask(markerPercent: number): string {
+  const gapStart = `calc(${markerPercent}% - 3px)`;
+  const gapEnd = `calc(${markerPercent}% + 3px)`;
+  return `linear-gradient(to right, black ${gapStart}, transparent ${gapStart}, transparent ${gapEnd}, black ${gapEnd})`;
+}
+
+export default function ProgressBar({ className, markerPercent, percent }: ProgressBarProps) {
+  const fillPercent = clampPercent(percent);
+  const cutMask = markerPercent === undefined ? undefined : buildCutMask(clampPercent(markerPercent));
+
+  return (
+    <div
+      aria-valuemax={100}
+      aria-valuemin={0}
+      aria-valuenow={Math.round(fillPercent)}
+      className={cn("relative h-2 w-full", className)}
+      role="progressbar"
+    >
+      <div
+        className="absolute inset-0 rounded-full bg-muted"
+        style={cutMask === undefined ? undefined : { WebkitMaskImage: cutMask, maskImage: cutMask }}
+      >
+        <div className="absolute inset-0 overflow-hidden rounded-full">
+          <div
+            className="h-full rounded-full bg-primary transition-[width]"
+            style={{ width: `${fillPercent}%` }}
+          />
+        </div>
+      </div>
+      {markerPercent !== undefined && (
+        <div
+          aria-hidden
+          className="absolute inset-y-0 w-0.5 -translate-x-1/2 bg-green-600"
+          style={{ left: `${clampPercent(markerPercent)}%` }}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/app/_components/progress-bar.tsx
+++ b/src/app/_components/progress-bar.tsx
@@ -1,6 +1,8 @@
 import { cn } from "@/lib/utils";
 
 type ProgressBarProps = {
+  /** 进度条的无障碍名称（同屏多条时按币种区分） */
+  ariaLabel: string;
   className?: string;
   /** 可选标记位置（0-100），不传则不渲染标记；超出范围会被 clamp */
   markerPercent?: number;
@@ -12,19 +14,20 @@ function clampPercent(value: number): number {
   return Math.min(Math.max(value, 0), 100);
 }
 
-// 标记两侧各 2px 用 mask 把轨道+填充抠出透明缺口，直接露出下方底色（无需关心表面色）
+// 以标记为中心用 mask 抠出 ±3px（共 6px）透明缺口：2px 标记线居中，两侧各留 2px 露出底色（无需关心表面色）
 function buildCutMask(markerPercent: number): string {
   const gapStart = `calc(${markerPercent}% - 3px)`;
   const gapEnd = `calc(${markerPercent}% + 3px)`;
   return `linear-gradient(to right, black ${gapStart}, transparent ${gapStart}, transparent ${gapEnd}, black ${gapEnd})`;
 }
 
-export default function ProgressBar({ className, markerPercent, percent }: ProgressBarProps) {
+export default function ProgressBar({ ariaLabel, className, markerPercent, percent }: ProgressBarProps) {
   const fillPercent = clampPercent(percent);
   const cutMask = markerPercent === undefined ? undefined : buildCutMask(clampPercent(markerPercent));
 
   return (
     <div
+      aria-label={ariaLabel}
       aria-valuemax={100}
       aria-valuemin={0}
       aria-valuenow={Math.round(fillPercent)}
@@ -42,11 +45,12 @@ export default function ProgressBar({ className, markerPercent, percent }: Progr
           />
         </div>
       </div>
+      {/* 标记线左边缘 clamp 在条内：月初 0% / 月末 100% 时贴边且不超出进度条 */}
       {markerPercent !== undefined && (
         <div
           aria-hidden
-          className="absolute inset-y-0 w-0.5 -translate-x-1/2 bg-green-600"
-          style={{ left: `${clampPercent(markerPercent)}%` }}
+          className="absolute inset-y-0 w-0.5 bg-green-600"
+          style={{ left: `clamp(0px, calc(${clampPercent(markerPercent)}% - 1px), calc(100% - 2px))` }}
         />
       )}
     </div>


### PR DESCRIPTION
## 摘要

`/record/@usage` 的进度条抽为共享组件 `ProgressBar`（`src/app/_components/progress-bar.tsx`），新增可选参数 `markerPercent`：在对应百分比位置渲染一条与进度条等高的绿色（`green-600`）竖线标记，两侧用 `mask-image` 渐变抠出透明小缺口——深浅色主题通用，不依赖表面色 token。@usage 传入本月时间进度，用于直观对比消费进度与时间进度。

## 改动

- 新增 `ProgressBar` 组件：`percent` + 可选 `markerPercent`，均 clamp 到 [0,100]；带 `role="progressbar"` 与 aria 属性；不传 `markerPercent` 时与原样式一致
- `src/api/usage.ts`：新增 `getMonthElapsedPercent`（今天含在内 ÷ 当月总天数，浏览器本地时区，与 month key 口径一致）；`UsageSummary` 增加 `monthElapsedPercent` 字段
- `@usage` 页面改用 `ProgressBar` 并传入 `markerPercent={data.monthElapsedPercent}`
- `usage.test.ts` 补 5 个用例：月中、月末 100%、平年 2 月 50%、闰年 2/29、每月 1 日
- AGENTS.md 同步目录约定与标记语义（含本项目主题靠 `prefers-color-scheme` 媒体查询驱动、class 式 `dark:` 变体不生效的说明）

## 验证

- `pnpm test` 30 通过
- `pnpm lint` 无告警
- `pnpm build` 通过（含 TS 全量检查）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a reusable progress bar for monthly budget tracking.
  * Added a visual marker showing elapsed time in the current month.
  * Progress values are safely constrained and presented with accessible status information.

* **Bug Fixes**
  * Improved monthly percentage calculations, including leap years, month boundaries, and the first day of the month.

* **Documentation**
  * Updated guidance for progress-bar usage and time-progress markers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->